### PR TITLE
Skip update events where `data: null` if the data was NOT null in the source doc (i.e. no-op)

### DIFF
--- a/main.js
+++ b/main.js
@@ -57,6 +57,8 @@ function parseParallelism(value, dummyPrevious) {
   lastProcessed.updates.ts = options.timestamp;
   lastProcessed.removes.ts = options.timestamp;
 
+  console.log(`BEGIN synchronizing events in collection '${options.collection}' at ${new Date().toISOString()}`);
+
   let res = await migrate(options.collection, index, duration, size, options.source, options.target, options.parallelism);
 
   while (
@@ -78,6 +80,8 @@ function parseParallelism(value, dummyPrevious) {
   if (!res) {
     throw new Error("Validation error; can't continue");
   }
+
+  console.log(`END synchronizing events in collection '${options.collection}' at ${new Date().toISOString()}`);
 })().catch((err) => {
   console.error(err);
   process.exit(1);

--- a/migrate-db.js
+++ b/migrate-db.js
@@ -5,6 +5,7 @@ const {
 } = require("./functions.js");
 
 const {
+  At,
   Let,
   Get,
   Var,
@@ -373,6 +374,8 @@ async function flattenAndSortEvents(docEvents = [], collEvents = [], maxParallel
         if (eventQuery) {
           eventQueries.push(eventQuery);
           seenIds.push(evt.doc.id);
+        } else {
+          i--;
         }
 
         sortedEvents.shift();


### PR DESCRIPTION
There appear to be a couple scenarios where an `update` event can have `data: null`:

1. The changes in the call to `Update` yield no change in the doc
2. The call to `Update` explicitly sets `data: null`

We only want to apply the latter, assuming that clearing the `data` field is intentional, so in the migration tool, we have to check the state of the doc `At(ts)` and if the `data` field is not null, skip the current event (no-op), else let the null update through.