### PR TITLE
Use a do-while loop after initialization change

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,14 +112,14 @@ Epoch(1698969600000000, "microseconds") // Time("2023-11-03T00:00:00Z")
 
 Several constants are defined in `main.js` that can be adjusted to optimize the performance of the tool.
 
--  `duration` - (default: 30) fetch events for the time duration in minutes
+-  `duration` - (default: 30) Time span (in minutes) to gather events
    -  Increase the `duration` constant to widen the window of events that are processed at once, or decrease it to avoid rate limiting.
--  `interval` - (default: 30)  time to pause between reading and applying events - in seconds
-   -  Decrease the `interval` constant to take less time between iterations, or increase it to avoid rate limiting.
--  `iterations` - (default: 20)  Define the total number of iterations.
+-  `iterations` - (default: 20)  Number of iterations to run the tool
    -  The overall window of events that are processed is `duration` * `iterations` minutes.
--  `size` - (default: 64) page size
-   -  You should not need to change this. The tool paginates through all events in the duration window. There is little benefit to increasing or decreasing the page size.
+-  `interval` - (default: 10)  Wait time between iterations in seconds
+   -  Decrease the `interval` constant to take less time between iterations, or increase it to avoid rate limiting.
+-  `size` - (default: 64) Page size for retrieving documents from the custom index
+   -  If your documents are very large, you may want to decrease this value to limit the amount of data processed per transaction. Otherwise, you should not need to change this. The tool paginates through all events in the duration window. There is typically little benefit to increasing or decreasing the page size.
 
 These constants are optimized for migration of databases with a large number of events in each 30 minute window. If you want to change performance, start with the `duration` constant and adjust the others as needed.
 

--- a/main.js
+++ b/main.js
@@ -31,7 +31,7 @@ const { program } = require("commander");
     var index = options.index ?? "_migration_index_for_" + options.collection;
 
     // TUNABLE CONSTANTS
-    var duration = 30;   // Time span (in minutes) to gather events from
+    var duration = 30;   // Time span (in minutes) to gather events
     var iterations = 20; // Number of iterations to run the tool
     var interval = 10;   // Wait time between iterations in seconds
     var size = 64;       // Page size for retrieving documents from the custom index

--- a/main.js
+++ b/main.js
@@ -31,10 +31,10 @@ const { program } = require("commander");
     var index = options.index ?? "_migration_index_for_" + options.collection;
 
     // TUNABLE CONSTANTS
-    var duration = 30; //fetch events for the time duration in minutes
-    var size = 64; //page size
-    var interval = 10; // time to pause between reading and applying events - in seconds
-    var iterations = 20; // Define the total number of iterations
+    var duration = 30;   // Time span (in minutes) to gather events from
+    var iterations = 20; // Number of iterations to run the tool
+    var interval = 10;   // Wait time between iterations in seconds
+    var size = 64;       // Page size for retrieving documents from the custom index
 
     lastProcessed.startTime = options.timestamp;
     lastProcessed.updates.ts = options.timestamp;

--- a/main.js
+++ b/main.js
@@ -33,7 +33,7 @@ const { program } = require("commander");
     // TUNABLE CONSTANTS
     var duration = 30; //fetch events for the time duration in minutes
     var size = 64; //page size
-    var interval = 30; // time to pause between reading and applying events - in seconds
+    var interval = 10; // time to pause between reading and applying events - in seconds
     var iterations = 20; // Define the total number of iterations
 
     lastProcessed.startTime = options.timestamp;
@@ -47,12 +47,9 @@ const { program } = require("commander");
       throw new Error("Initialization error; can't continue")
     }
 
-    await migrate(options.collection, index, duration, size, options.parallelism);
+    do {
+      await migrate(options.collection, index, duration, size, options.parallelism);
 
-    while (
-      iterations > 0 &&
-      lastProcessed.startTime < Date.now() * 1000
-    ) {
       lastProcessed.startTime += duration * 60 * 1000 * 1000; //increase the start time by 'duration' amount of minutes at every iteration
 
       await pause(interval * 1000).then(
@@ -60,9 +57,10 @@ const { program } = require("commander");
       ); //sleep in ms
 
       iterations--;
-
-      await migrate(options.collection, index, duration, size, options.parallelism);
-    }
+    } while (
+      iterations > 0 &&
+      lastProcessed.startTime < Date.now() * 1000
+    )
 
     console.log(`END synchronizing events in collection '${options.collection}' at ${new Date().toISOString()}`);
   }


### PR DESCRIPTION
I noticed after rerunning the tool that the last iteration looks too far in the future, so I reordered the `while` loop now that the initialization is a separate step (used to be part of the `while` conditional).

Also reducing default wait time between iterations to 10 seconds.